### PR TITLE
[api] Delete Profile api 구현

### DIFF
--- a/FunchApp.xcodeproj/project.pbxproj
+++ b/FunchApp.xcodeproj/project.pbxproj
@@ -131,6 +131,7 @@
 		3EA875512B83C11E00713C64 /* SubwayLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875502B83C11E00713C64 /* SubwayLines.swift */; };
 		3EA875532B83C4EE00713C64 /* SubwayChemistryLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875522B83C4EE00713C64 /* SubwayChemistryLabel.swift */; };
 		3EA875552B843EEC00713C64 /* SubwayChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875542B843EEC00713C64 /* SubwayChipView.swift */; };
+		3EA875662B8645AE00713C64 /* DeleteProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */; };
 		3EE810682B7F74CE007B8A87 /* ImageResource+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE810672B7F74CE007B8A87 /* ImageResource+.swift */; };
 		3EE8106B2B806DC6007B8A87 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 3EE8106A2B806DC6007B8A87 /* Lottie */; };
 		3EE8106E2B80705D007B8A87 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE8106D2B80705D007B8A87 /* SplashView.swift */; };
@@ -240,6 +241,7 @@
 		3EA875522B83C4EE00713C64 /* SubwayChemistryLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubwayChemistryLabel.swift; sourceTree = "<group>"; };
 		3EA875542B843EEC00713C64 /* SubwayChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubwayChipView.swift; sourceTree = "<group>"; };
 		3EA8755A2B84DB2C00713C64 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteProfileUseCase.swift; sourceTree = "<group>"; };
 		3EE810672B7F74CE007B8A87 /* ImageResource+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageResource+.swift"; sourceTree = "<group>"; };
 		3EE8106D2B80705D007B8A87 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		3EE810702B8076F5007B8A87 /* Funch_splash_logo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Funch_splash_logo.json; sourceTree = "<group>"; };
@@ -559,6 +561,7 @@
 		1ACE496F2B5BA27600024336 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */,
 				1ACE49692B5BA19200024336 /* CreateProfileUseCase.swift */,
 				1A87EB092B6E0DCC0059F80A /* FetchProfileUseCase.swift */,
 			);
@@ -937,6 +940,7 @@
 				1ACE49582B5B9ECE00024336 /* MatchResultView.swift in Sources */,
 				1A7B06922B5D67250024356C /* SubwayStationRepositoryType.swift in Sources */,
 				1A7B06902B5D669A0024356C /* SubwayStationRepository.swift in Sources */,
+				3EA875662B8645AE00713C64 /* DeleteProfileUseCase.swift in Sources */,
 				3E1E73FC2B74AC510082386A /* Gradient+.swift in Sources */,
 				3EE810762B81D234007B8A87 /* MatchResultViewModel.swift in Sources */,
 				1A83F0332B80E6E000E6EC89 /* ProfileViewModel.swift in Sources */,

--- a/FunchApp.xcodeproj/project.pbxproj
+++ b/FunchApp.xcodeproj/project.pbxproj
@@ -136,6 +136,9 @@
 		3EA875662B8645AE00713C64 /* DeleteProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */; };
 		3EA875682B86492B00713C64 /* DeleteProfile.Res.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875672B86492B00713C64 /* DeleteProfile.Res.swift */; };
 		3EA8756A2B8654E000713C64 /* DeleteProfileQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875632B86447B00713C64 /* DeleteProfileQuery.swift */; };
+		3EA8756C2B8656EF00713C64 /* DeleteProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */; };
+		3EA8756D2B86570B00713C64 /* DeleteProfile.Req.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875612B86434800713C64 /* DeleteProfile.Req.swift */; };
+		3EA8756E2B86571000713C64 /* DeleteProfile.Res.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875672B86492B00713C64 /* DeleteProfile.Res.swift */; };
 		3EE810682B7F74CE007B8A87 /* ImageResource+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE810672B7F74CE007B8A87 /* ImageResource+.swift */; };
 		3EE8106B2B806DC6007B8A87 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 3EE8106A2B806DC6007B8A87 /* Lottie */; };
 		3EE8106E2B80705D007B8A87 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE8106D2B80705D007B8A87 /* SplashView.swift */; };
@@ -864,17 +867,20 @@
 				3E1E73EF2B7071030082386A /* SubwayStationRepositoryTests.swift in Sources */,
 				1A87EAEA2B691F2D0059F80A /* DefaultTargetType.swift in Sources */,
 				1A87EAF42B691FA20059F80A /* SubwayStationRepositoryType.swift in Sources */,
+				3EA8756C2B8656EF00713C64 /* DeleteProfileUseCase.swift in Sources */,
 				1A87EAF72B691FA90059F80A /* Profile.swift in Sources */,
 				1A87EAF52B691FA50059F80A /* MatchingRepositoryType.swift in Sources */,
 				1A87EAF92B691FB00059F80A /* CreateUserQuery.swift in Sources */,
 				1A87EADE2B691C510059F80A /* SubwayStationRepository.swift in Sources */,
 				1A87EAE72B691E6D0059F80A /* RequestDTO.swift in Sources */,
 				1A87EAEC2B691F420059F80A /* DictionaryType.swift in Sources */,
+				3EA8756E2B86571000713C64 /* DeleteProfile.Res.swift in Sources */,
 				1A87EB032B6920050059F80A /* GetProfileFromId.Req.swift in Sources */,
 				1A87EAFE2B691FF80059F80A /* SearchUser.Res.swift in Sources */,
 				1A87EAEE2B691F470059F80A /* View+.swift in Sources */,
 				3E28CC682B7E624F00818CD3 /* Array+.swift in Sources */,
 				1A87EAED2B691F450059F80A /* UIDeivce+.swift in Sources */,
+				3EA8756D2B86570B00713C64 /* DeleteProfile.Req.swift in Sources */,
 				1A87EB0D2B6E10A40059F80A /* FetchUserQuery.swift in Sources */,
 				1A87EB012B6920010059F80A /* CreateProfile.Req.swift in Sources */,
 				3E28CC672B7E61E000818CD3 /* SearchSubway.Res.swift in Sources */,

--- a/FunchApp.xcodeproj/project.pbxproj
+++ b/FunchApp.xcodeproj/project.pbxproj
@@ -131,7 +131,11 @@
 		3EA875512B83C11E00713C64 /* SubwayLines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875502B83C11E00713C64 /* SubwayLines.swift */; };
 		3EA875532B83C4EE00713C64 /* SubwayChemistryLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875522B83C4EE00713C64 /* SubwayChemistryLabel.swift */; };
 		3EA875552B843EEC00713C64 /* SubwayChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875542B843EEC00713C64 /* SubwayChipView.swift */; };
+		3EA875622B86434800713C64 /* DeleteProfile.Req.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875612B86434800713C64 /* DeleteProfile.Req.swift */; };
+		3EA875642B86447B00713C64 /* DeleteProfileQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875632B86447B00713C64 /* DeleteProfileQuery.swift */; };
 		3EA875662B8645AE00713C64 /* DeleteProfileUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */; };
+		3EA875682B86492B00713C64 /* DeleteProfile.Res.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875672B86492B00713C64 /* DeleteProfile.Res.swift */; };
+		3EA8756A2B8654E000713C64 /* DeleteProfileQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA875632B86447B00713C64 /* DeleteProfileQuery.swift */; };
 		3EE810682B7F74CE007B8A87 /* ImageResource+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE810672B7F74CE007B8A87 /* ImageResource+.swift */; };
 		3EE8106B2B806DC6007B8A87 /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = 3EE8106A2B806DC6007B8A87 /* Lottie */; };
 		3EE8106E2B80705D007B8A87 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE8106D2B80705D007B8A87 /* SplashView.swift */; };
@@ -241,7 +245,10 @@
 		3EA875522B83C4EE00713C64 /* SubwayChemistryLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubwayChemistryLabel.swift; sourceTree = "<group>"; };
 		3EA875542B843EEC00713C64 /* SubwayChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubwayChipView.swift; sourceTree = "<group>"; };
 		3EA8755A2B84DB2C00713C64 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
+		3EA875612B86434800713C64 /* DeleteProfile.Req.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteProfile.Req.swift; sourceTree = "<group>"; };
+		3EA875632B86447B00713C64 /* DeleteProfileQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteProfileQuery.swift; sourceTree = "<group>"; };
 		3EA875652B8645AE00713C64 /* DeleteProfileUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeleteProfileUseCase.swift; sourceTree = "<group>"; };
+		3EA875672B86492B00713C64 /* DeleteProfile.Res.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeleteProfile.Res.swift; sourceTree = "<group>"; };
 		3EE810672B7F74CE007B8A87 /* ImageResource+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ImageResource+.swift"; sourceTree = "<group>"; };
 		3EE8106D2B80705D007B8A87 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
 		3EE810702B8076F5007B8A87 /* Funch_splash_logo.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Funch_splash_logo.json; sourceTree = "<group>"; };
@@ -288,6 +295,7 @@
 				1A44AAA82B67E848006D8894 /* GetProfileFromId.Req.swift */,
 				1A792B8A2B5D62BE00A080F2 /* MatchingUser.Req.swift */,
 				1A7B06992B5D68AC0024356C /* SearchSubwayStation.Req.swift */,
+				3EA875612B86434800713C64 /* DeleteProfile.Req.swift */,
 			);
 			path = RequestDTO;
 			sourceTree = "<group>";
@@ -311,6 +319,7 @@
 				1ACE497C2B5BA3B600024336 /* CreateProfile.Res.swift */,
 				1A44AAAD2B67F218006D8894 /* MatchingUser.Res.swift */,
 				1A87EB4A2B6FEF2A0059F80A /* SearchSubway.Res.swift */,
+				3EA875672B86492B00713C64 /* DeleteProfile.Res.swift */,
 			);
 			path = ResponseDTO;
 			sourceTree = "<group>";
@@ -322,6 +331,7 @@
 				1A792B882B5D62A300A080F2 /* MatchingUserQuery.swift */,
 				1A7B06972B5D68650024356C /* SearchSubwayStationQuery.swift */,
 				1A87EB0B2B6E0FA10059F80A /* FetchUserQuery.swift */,
+				3EA875632B86447B00713C64 /* DeleteProfileQuery.swift */,
 			);
 			path = Request;
 			sourceTree = "<group>";
@@ -869,6 +879,7 @@
 				1A87EB012B6920010059F80A /* CreateProfile.Req.swift in Sources */,
 				3E28CC672B7E61E000818CD3 /* SearchSubway.Res.swift in Sources */,
 				1A87EADF2B691C510059F80A /* MatchingRepository.swift in Sources */,
+				3EA8756A2B8654E000713C64 /* DeleteProfileQuery.swift in Sources */,
 				1A87EAF82B691FAC0059F80A /* MatchingInfo.swift in Sources */,
 				1A87EAFC2B691FEA0059F80A /* UserDataStorage.swift in Sources */,
 				1A87EAE92B691E730059F80A /* Requestable.swift in Sources */,
@@ -898,6 +909,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3EA875622B86434800713C64 /* DeleteProfile.Req.swift in Sources */,
 				3EE8107C2B8318EC007B8A87 /* ProfileEditorViewBuilder.swift in Sources */,
 				1A45882F2B64D70700FBB841 /* SearchUser.Res.swift in Sources */,
 				1ACE49542B5B9E6400024336 /* HomeView.swift in Sources */,
@@ -923,10 +935,12 @@
 				3EE8106E2B80705D007B8A87 /* SplashView.swift in Sources */,
 				1ACE49642B5B9F4A00024336 /* Profile.swift in Sources */,
 				1A83F02C2B80E1BD00E6EC89 /* HomeViewModel.swift in Sources */,
+				3EA875682B86492B00713C64 /* DeleteProfile.Res.swift in Sources */,
 				1A7B06A22B5D8C710024356C /* MatchingInfo.swift in Sources */,
 				1ACE497D2B5BA3B600024336 /* CreateProfile.Res.swift in Sources */,
 				1A83F02E2B80E26B00E6EC89 /* MatchResultViewBuilder.swift in Sources */,
 				1A83F0232B80C5A900E6EC89 /* Services.swift in Sources */,
+				3EA875642B86447B00713C64 /* DeleteProfileQuery.swift in Sources */,
 				1A7B06942B5D67570024356C /* DictionaryType.swift in Sources */,
 				1ACE495C2B5B9EF200024336 /* OnboardingView.swift in Sources */,
 				3EA69C3F2B64C086008AE23B /* CGFloat+.swift in Sources */,

--- a/FunchApp/Core/Network/DefaultTargetType.swift
+++ b/FunchApp/Core/Network/DefaultTargetType.swift
@@ -21,7 +21,7 @@ enum DefaultTargetType {
     /// 타인 프로필 검색
     case matchingUser(parameters: DictionaryType)
     /// 프로필 삭제
-    case deleteUserProfile
+    case deleteUserProfile(path: String)
 }
 
 extension DefaultTargetType: TargetType {
@@ -45,8 +45,8 @@ extension DefaultTargetType: TargetType {
             return "/v1/members"
         case .searchSubwayStations(_):
             return "/v1/subway-stations/search"
-        case .deleteUserProfile:
-            return "v1/"
+        case let .deleteUserProfile(id):
+            return "v1/members/\(id)"
         }
     }
     
@@ -58,16 +58,17 @@ extension DefaultTargetType: TargetType {
             return .get
             
         case .createUserProfile(_),
-                .matchingUser(_),
-                .deleteUserProfile:
+                .matchingUser(_):
             return .post
             
+        case .deleteUserProfile(_):
+            return .delete
         }
     }
 
     var task: Task {
         switch self {
-        case .getUserProfileFromId(_), .deleteUserProfile:
+        case .getUserProfileFromId(_), .deleteUserProfile(_):
             return .requestPlain
             
         case .getUserProfileFromDeviceId(let parameters),

--- a/FunchApp/Core/Network/DefaultTargetType.swift
+++ b/FunchApp/Core/Network/DefaultTargetType.swift
@@ -20,6 +20,8 @@ enum DefaultTargetType {
     case searchSubwayStations(parameters: DictionaryType)
     /// 타인 프로필 검색
     case matchingUser(parameters: DictionaryType)
+    /// 프로필 삭제
+    case deleteUserProfile
 }
 
 extension DefaultTargetType: TargetType {
@@ -43,6 +45,8 @@ extension DefaultTargetType: TargetType {
             return "/v1/members"
         case .searchSubwayStations(_):
             return "/v1/subway-stations/search"
+        case .deleteUserProfile:
+            return "v1/"
         }
     }
     
@@ -54,7 +58,8 @@ extension DefaultTargetType: TargetType {
             return .get
             
         case .createUserProfile(_),
-                .matchingUser(_):
+                .matchingUser(_),
+                .deleteUserProfile:
             return .post
             
         }
@@ -62,7 +67,7 @@ extension DefaultTargetType: TargetType {
 
     var task: Task {
         switch self {
-        case .getUserProfileFromId(_):
+        case .getUserProfileFromId(_), .deleteUserProfile:
             return .requestPlain
             
         case .getUserProfileFromDeviceId(let parameters),

--- a/FunchApp/Data/DataMapping/RequestDTO/DeleteProfile.Req.swift
+++ b/FunchApp/Data/DataMapping/RequestDTO/DeleteProfile.Req.swift
@@ -1,0 +1,23 @@
+//
+//  DeleteProfile.Req.swift
+//  FunchApp
+//
+//  Created by 이성민 on 2/21/24.
+//
+
+import Foundation
+
+extension RequestDTO {
+    struct DeleteProfile: Requestable {
+        
+        var profileId: Int
+        
+        init(query: DeleteProfileQuery) {
+            profileId = query.profileId
+        }
+        
+        var path: String {
+            "\(profileId)"
+        }
+    }
+}

--- a/FunchApp/Data/DataMapping/RequestDTO/DeleteProfile.Req.swift
+++ b/FunchApp/Data/DataMapping/RequestDTO/DeleteProfile.Req.swift
@@ -10,7 +10,7 @@ import Foundation
 extension RequestDTO {
     struct DeleteProfile: Requestable {
         
-        var profileId: Int
+        var profileId: String
         
         init(query: DeleteProfileQuery) {
             profileId = query.profileId

--- a/FunchApp/Data/DataMapping/ResponseDTO/DeleteProfile.Res.swift
+++ b/FunchApp/Data/DataMapping/ResponseDTO/DeleteProfile.Res.swift
@@ -1,0 +1,8 @@
+//
+//  DeleteProfile.Res.swift
+//  FunchApp
+//
+//  Created by 이성민 on 2/22/24.
+//
+
+import Foundation

--- a/FunchApp/Data/DataMapping/ResponseDTO/DeleteProfile.Res.swift
+++ b/FunchApp/Data/DataMapping/ResponseDTO/DeleteProfile.Res.swift
@@ -6,3 +6,17 @@
 //
 
 import Foundation
+
+extension ResponseDTO {
+    struct DeleteProfile: Respondable {
+        var status: String
+        var message: String
+        var data: String
+    }
+}
+
+extension ResponseDTO.DeleteProfile {
+    func toDomain() -> String {
+        return data
+    }
+}

--- a/FunchApp/Data/Repository/ProfileRepository.swift
+++ b/FunchApp/Data/Repository/ProfileRepository.swift
@@ -86,4 +86,9 @@ final class ProfileRepository: ProfileRepositoryType {
             }
         }
     }
+    
+    func deleteProfile(completion: @escaping (Result<Void, MoyaError>) -> Void) {
+        completion(.success(()))
+        // TODO: 삭제 api 연결
+    }
 }

--- a/FunchApp/Data/Repository/ProfileRepository.swift
+++ b/FunchApp/Data/Repository/ProfileRepository.swift
@@ -42,7 +42,7 @@ final class ProfileRepository: ProfileRepositoryType {
         }
     }
     
-    /// 내 프로필 디바이스 기반 정보 조회
+    /// 내 프로필 Id 기반 정보 조회
     func fetchProfileId(
         userQuery: FetchUserQuery,
         completion: @escaping (Result<Profile, MoyaError>) -> Void
@@ -87,8 +87,25 @@ final class ProfileRepository: ProfileRepositoryType {
         }
     }
     
-    func deleteProfile(completion: @escaping (Result<Void, MoyaError>) -> Void) {
-        completion(.success(()))
-        // TODO: 삭제 api 연결
+    func deleteProfile(
+        userQuery: DeleteProfileQuery,
+        completion: @escaping (Result<String, MoyaError>) -> Void
+    ) {
+        let requestDTO = RequestDTO.DeleteProfile(query: userQuery)
+        apiClient.request(
+            ResponseDTO.DeleteProfile.self,
+            target: .deleteUserProfile(path: requestDTO.path)
+        ) { result in
+            switch result {
+            case .success(let success):
+                SwiftUI.Task { @MainActor in
+                    completion(.success(success.toDomain()))
+                }
+            case .failure(let failure):
+                SwiftUI.Task { @MainActor in
+                    completion(.failure(failure))
+                }
+            }
+        }
     }
 }

--- a/FunchApp/Domain/Entities/Request/DeleteProfileQuery.swift
+++ b/FunchApp/Domain/Entities/Request/DeleteProfileQuery.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct DeleteProfileQuery {
     /// 삭제할 프로필 id
-    var profileId: Int
+    var profileId: String
     
-    init(profileId: Int) {
+    init(profileId: String) {
         self.profileId = profileId
     }
 }

--- a/FunchApp/Domain/Entities/Request/DeleteProfileQuery.swift
+++ b/FunchApp/Domain/Entities/Request/DeleteProfileQuery.swift
@@ -1,0 +1,17 @@
+//
+//  DeleteProfileQuery.swift
+//  FunchApp
+//
+//  Created by 이성민 on 2/21/24.
+//
+
+import Foundation
+
+struct DeleteProfileQuery {
+    /// 삭제할 프로필 id
+    var profileId: Int
+    
+    init(profileId: Int) {
+        self.profileId = profileId
+    }
+}

--- a/FunchApp/Domain/Interfaces/ProfileRepositoryType.swift
+++ b/FunchApp/Domain/Interfaces/ProfileRepositoryType.swift
@@ -18,5 +18,8 @@ protocol ProfileRepositoryType {
         createUserQuery: CreateUserQuery,
         completion: @escaping (Result<Profile, MoyaError>) -> Void
     )
-    func deleteProfile(completion: @escaping (Result<Void, MoyaError>) -> Void)
+    func deleteProfile(
+        userQuery: DeleteProfileQuery,
+        completion: @escaping (Result<String, MoyaError>) -> Void
+    )
 }

--- a/FunchApp/Domain/Interfaces/ProfileRepositoryType.swift
+++ b/FunchApp/Domain/Interfaces/ProfileRepositoryType.swift
@@ -18,4 +18,5 @@ protocol ProfileRepositoryType {
         createUserQuery: CreateUserQuery,
         completion: @escaping (Result<Profile, MoyaError>) -> Void
     )
+    func deleteProfile(completion: @escaping (Result<Void, MoyaError>) -> Void)
 }

--- a/FunchApp/Domain/UseCase/Profile/DeleteProfileUseCase.swift
+++ b/FunchApp/Domain/UseCase/Profile/DeleteProfileUseCase.swift
@@ -8,7 +8,10 @@
 import Foundation
 
 protocol DeleteProfileUseCaseType {
-    func deleteProfile(completion: @escaping (Result<Void, Error>) -> Void)
+    func deleteProfile(
+        requestId: String,
+        completion: @escaping (Result<String, Error>) -> Void
+    )
 }
 
 final class DeleteProfileUseCase: DeleteProfileUseCaseType {
@@ -18,12 +21,16 @@ final class DeleteProfileUseCase: DeleteProfileUseCaseType {
         self.profileRepository = ProfileRepository()
     }
     
-    func deleteProfile(completion: @escaping (Result<Void, Error>) -> Void) {
-        profileRepository.deleteProfile { result in
+    func deleteProfile(
+        requestId: String,
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
+        let query = DeleteProfileQuery(profileId: requestId)
+        profileRepository.deleteProfile(userQuery: query) { result in
             switch result {
-            case .success(let result):
-                DispatchQueue.main.async {
-                    completion(.success(result))
+            case .success(let deletedId):
+                Task { @MainActor in
+                    completion(.success(deletedId))
                 }
             case .failure(let error):
                 completion(.failure(error))

--- a/FunchApp/Domain/UseCase/Profile/DeleteProfileUseCase.swift
+++ b/FunchApp/Domain/UseCase/Profile/DeleteProfileUseCase.swift
@@ -6,3 +6,28 @@
 //
 
 import Foundation
+
+protocol DeleteProfileUseCaseType {
+    func deleteProfile(completion: @escaping (Result<Void, Error>) -> Void)
+}
+
+final class DeleteProfileUseCase: DeleteProfileUseCaseType {
+    private let profileRepository: ProfileRepositoryType
+    
+    init() {
+        self.profileRepository = ProfileRepository()
+    }
+    
+    func deleteProfile(completion: @escaping (Result<Void, Error>) -> Void) {
+        profileRepository.deleteProfile { result in
+            switch result {
+            case .success(let result):
+                DispatchQueue.main.async {
+                    completion(.success(result))
+                }
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+}

--- a/FunchApp/Domain/UseCase/Profile/DeleteProfileUseCase.swift
+++ b/FunchApp/Domain/UseCase/Profile/DeleteProfileUseCase.swift
@@ -1,0 +1,8 @@
+//
+//  DeleteProfileUseCase.swift
+//  FunchApp
+//
+//  Created by 이성민 on 2/21/24.
+//
+
+import Foundation

--- a/FunchApp/Presentation/HomeScene/HomeView.swift
+++ b/FunchApp/Presentation/HomeScene/HomeView.swift
@@ -47,6 +47,9 @@ struct HomeView: View {
         .onAppear {
             viewModel.send(action: .load)
         }
+        .onTapGesture {
+            hideKeyboard()
+        }
         .fullScreenCover(item: $viewModel.presentation) { presentation in
             switch presentation {
             case .profile:

--- a/FunchApp/Presentation/ProfileScene/ProfileView.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct ProfileView: View {
     
     @Environment(\.dismiss) var dismiss
+    @EnvironmentObject var appCoordinator: AppCoordinator
     @StateObject var viewModel: ProfileViewModel
     
     @State private var showingAlert: Bool = false
@@ -48,8 +49,18 @@ struct ProfileView: View {
             }
         }
         .alert("프로필 삭제하기", isPresented: $showingAlert, actions: {
-            Button(role: .cancel, action: { print("test") }, label: { Text("취소하기") })
-            Button(role: .destructive, action: { print("deleted") }, label: { Text("삭제하기") })
+            Button(role: .cancel) {
+                showingAlert = false
+            } label: {
+                Text("취소하기")
+            }
+            
+            Button(role: .destructive) {
+                viewModel.send(action: .deleteProfile)
+                // viewModel과 연결
+            } label: {
+                Text("삭제하기")
+            }
         }, message: {
             Text("기존 프로필이 삭제되고 복구가 불가능해요.\n정말 삭제하실 건가요?")
         })
@@ -59,6 +70,14 @@ struct ProfileView: View {
         .onReceive(viewModel.$dismiss) { boolean in
             if boolean {
                 dismiss()
+            }
+        }
+        .onReceive(viewModel.$presentation) { presentation in
+            switch presentation {
+            case .onboarding:
+                appCoordinator.paths.removeAll()
+            default:
+                break
             }
         }
         .toolbar {

--- a/FunchApp/Presentation/ProfileScene/ProfileView.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileView.swift
@@ -12,31 +12,47 @@ struct ProfileView: View {
     @Environment(\.dismiss) var dismiss
     @StateObject var viewModel: ProfileViewModel
     
+    @State private var showingAlert: Bool = false
+    
     var body: some View {
         ZStack {
             Color.gray900
                 .ignoresSafeArea(.all)
             
-            VStack {
-                Spacer()
-                    .frame(height: 8)
-                
-                VStack(alignment: .leading, spacing: 0) {
-                    if let profile = viewModel.profile {
-                        profileView(profile)
-                    } else {
-                        Text("프로필을 불러오는 중이에요.")
+            ScrollView {
+                VStack {
+                    Spacer()
+                        .frame(height: 8)
+                    
+                    VStack(alignment: .leading, spacing: 0) {
+                        if let profile = viewModel.profile {
+                            profileView(profile)
+                        } else {
+                            Text("프로필을 불러오는 중이에요.")
+                        }
                     }
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 20)
+                    .background(.gray800)
+                    .clipShape(RoundedRectangle(cornerRadius: 20))
+                    .padding(.horizontal, 24)
+                    
+                    Spacer()
+                        .frame(height: 20)
+                    
+                    deleteUserButton
+                    
+                    Spacer()
+                        .frame(height: 30)
                 }
-                .padding(.horizontal, 24)
-                .padding(.vertical, 20)
-                .background(.gray800)
-                .clipShape(RoundedRectangle(cornerRadius: 20))
-                .padding(.horizontal, 24)
-                
-                Spacer()
             }
         }
+        .alert("프로필 삭제하기", isPresented: $showingAlert, actions: {
+            Button(role: .cancel, action: { print("test") }, label: { Text("취소하기") })
+            Button(role: .destructive, action: { print("deleted") }, label: { Text("삭제하기") })
+        }, message: {
+            Text("기존 프로필이 삭제되고 복구가 불가능해요.\n정말 삭제하실 건가요?")
+        })
         .onAppear {
             viewModel.send(action: .load)
         }
@@ -69,6 +85,7 @@ struct ProfileView: View {
                 }
             }
         }
+        .toolbarBackground(Color.gray900, for: .navigationBar)
     }
     
     
@@ -130,6 +147,21 @@ struct ProfileView: View {
             
             Spacer()
         }
+    }
+    
+    private var deleteUserButton: some View {
+        Button {
+            showingAlert = true
+        } label: {
+            Text("프로필 삭제하기")
+                .font(.Funch.body)
+                .foregroundColor(.white)
+                .frame(maxHeight: .infinity)
+        }
+        .padding(.horizontal, 12)
+        .background(.gray800)
+        .frame(height: 36)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
     }
 }
 

--- a/FunchApp/Presentation/ProfileScene/ProfileViewBuilder.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileViewBuilder.swift
@@ -15,7 +15,8 @@ struct ProfileViewBuilder: Buildable {
     }
     
     var body: some View {
-        let viewModel = ProfileViewModel(container: container)
+        let useCase = DeleteProfileUseCase()
+        let viewModel = ProfileViewModel(container: container, useCase: useCase)
         let view = ProfileView(viewModel: viewModel)
         
         return view

--- a/FunchApp/Presentation/ProfileScene/ProfileViewModel.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileViewModel.swift
@@ -45,9 +45,15 @@ final class ProfileViewModel: ObservableObject {
             dismiss = true
             
         case .deleteProfile:
-            useCase.deleteProfile { result in
+            guard let userId = profile?.id else {
+                // TODO: 내가 프로필이 없다면 ?
+                return
+            }
+            useCase.deleteProfile(requestId: userId) { result in
                 switch result {
-                case .success(_):
+                case .success(let deletedId):
+                    // TODO: profiles 중에서 deletedId를 찾아 없애는 작업 필요
+                    // TODO: UserDefaults에서 Profile 형태가 아닌 Profile.id 형태로 저장 필요
                     self.container.services.userService.profiles = []
                     self.presentation = .onboarding
                 case .failure(_):

--- a/FunchApp/Presentation/ProfileScene/ProfileViewModel.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileViewModel.swift
@@ -12,16 +12,24 @@ final class ProfileViewModel: ObservableObject {
     enum Action {
         case load
         case loadFailed
+        case deleteProfile
         case feedback
     }
     
+    enum PresentationState {
+        case onboarding
+    }
+    
+    @Published var presentation: PresentationState?
     @Published var profile: Profile?
     @Published var dismiss: Bool = false
     
     private var container: DependencyType
+    private var useCase: DeleteProfileUseCaseType
     
-    init(container: DependencyType) {
+    init(container: DependencyType, useCase: DeleteProfileUseCaseType) {
         self.container = container
+        self.useCase = useCase
     }
     
     func send(action: Action) {
@@ -35,6 +43,18 @@ final class ProfileViewModel: ObservableObject {
             
         case .loadFailed:
             dismiss = true
+            
+        case .deleteProfile:
+            useCase.deleteProfile { result in
+                switch result {
+                case .success(_):
+                    self.container.services.userService.profiles = []
+                    self.presentation = .onboarding
+                case .failure(_):
+                    // 실패했을때는 어떤 처리 ...? 또 알러트 ??
+                    break
+                }
+            }
             
         case .feedback:
             container.services.openURLSerivce.execute(type: .feedback)

--- a/FunchAppTests/Repositories/ProfileRepositoryTests.swift
+++ b/FunchAppTests/Repositories/ProfileRepositoryTests.swift
@@ -84,6 +84,7 @@ final class ProfileRepositoryTests: XCTestCase {
         repository?.createProfile(createUserQuery: query) { result in
             switch result {
             case .success(let response):
+                dump(response)
                 XCTAssertTrue(true, "일단 api 성공하는지만 체크")
             case .failure(let failure):
                 XCTFail(failure.localizedDescription)
@@ -92,6 +93,25 @@ final class ProfileRepositoryTests: XCTestCase {
         }
         
         wait(for: [expectation], timeout: 5)
+    }
+    
+    /// 유저 삭제
+    func test_deleteProfile() {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 1
+        
+        /// createProfile 로 생성된 id로 삭제 테스트
+        let query = DeleteProfileQuery(profileId: "65d61fcf1cd2ab69d9f3f69e")
+        repository?.deleteProfile(userQuery: query, completion: { result in
+            switch result {
+            case .success(let response):
+                dump(response)
+                XCTAssertTrue(true, "일단 api 성공하는지만 체크")
+            case .failure(let failure):
+                XCTFail(failure.localizedDescription)
+            }
+            expectation.fulfill()
+        })
     }
 
 }


### PR DESCRIPTION
## 이슈번호 #105 


## 내용

프로필 삭제하는 api 구현 완료했습니다

참고사항으로는
- 삭제가 ProfileView에서 fetchProfile로 받아온 Profile의 userId로 삭제됩니다
- 삭제가 완료되면 UserDefaults에 있는 프로필에 냅다 빈 배열을 할당합니다
  - UserDefaults의 profiles에서 삭제된 userId를 찾은 후 그 프로필만 삭제하려고 했는데, 일단은 해당 로직을 여기서 짜는건 좋지 않을 것 같아 FIXME로 남겨뒀습니다

- 위에 이어서, 지금은 처음 앱을 켰을 때 UserDefaults에 프로필이 있냐 없냐로 첫 화면이 구분되는데, 사실 요것도 불필요하긴 하죠 ...
- 근데 막상 적다보니 애초에 프로필이 여러 개일 수가 없을거 같긴 합..니다...

## 참조
