### PR TITLE
[Architecture] SwiftUI Presentation Layer 구조 개선

### DIFF
--- a/FunchApp.xcodeproj/project.pbxproj
+++ b/FunchApp.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		1ACE49802B5BA46600024336 /* ProfileRepositoryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACE497F2B5BA46600024336 /* ProfileRepositoryImpl.swift */; };
 		1ACE49862B5BAB5F00024336 /* DefaultFunchButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACE49852B5BAB5F00024336 /* DefaultFunchButtonStyle.swift */; };
 		1ACE498D2B5C111500024336 /* ChipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ACE498C2B5C111500024336 /* ChipView.swift */; };
+		1AFB7D9C2B9D9387007E4D2F /* MultiProfileListDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFB7D9B2B9D9387007E4D2F /* MultiProfileListDelegate.swift */; };
+		1AFB7D9E2B9D9481007E4D2F /* ProfileViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AFB7D9D2B9D9481007E4D2F /* ProfileViewDelegate.swift */; };
 		3E1E73EF2B7071030082386A /* SubwayStationRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1E73EE2B7071030082386A /* SubwayStationRepositoryTests.swift */; };
 		3E1E73F12B70B3570082386A /* ChipButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1E73F02B70B3570082386A /* ChipButton.swift */; };
 		3E1E73F32B713B3A0082386A /* String+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E1E73F22B713B3A0082386A /* String+.swift */; };
@@ -257,6 +259,8 @@
 		1ACE497F2B5BA46600024336 /* ProfileRepositoryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileRepositoryImpl.swift; sourceTree = "<group>"; };
 		1ACE49852B5BAB5F00024336 /* DefaultFunchButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultFunchButtonStyle.swift; sourceTree = "<group>"; };
 		1ACE498C2B5C111500024336 /* ChipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipView.swift; sourceTree = "<group>"; };
+		1AFB7D9B2B9D9387007E4D2F /* MultiProfileListDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiProfileListDelegate.swift; sourceTree = "<group>"; };
+		1AFB7D9D2B9D9481007E4D2F /* ProfileViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewDelegate.swift; sourceTree = "<group>"; };
 		3E1E73EE2B7071030082386A /* SubwayStationRepositoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubwayStationRepositoryTests.swift; sourceTree = "<group>"; };
 		3E1E73F02B70B3570082386A /* ChipButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChipButton.swift; sourceTree = "<group>"; };
 		3E1E73F22B713B3A0082386A /* String+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+.swift"; sourceTree = "<group>"; };
@@ -488,6 +492,7 @@
 		1AC7812D2B91E6CC00E298E3 /* MultiProfileScene */ = {
 			isa = PBXGroup;
 			children = (
+				1AFB7D9B2B9D9387007E4D2F /* MultiProfileListDelegate.swift */,
 				1AC781362B923EEA00E298E3 /* MultiProfileListViewBuilder.swift */,
 				1AC7812B2B91E6C900E298E3 /* MultiProfileListView.swift */,
 				1AC781342B923EC800E298E3 /* MultiProfileListViewModel.swift */,
@@ -596,6 +601,7 @@
 		1ACE495E2B5B9EFF00024336 /* ProfileScene */ = {
 			isa = PBXGroup;
 			children = (
+				1AFB7D9D2B9D9481007E4D2F /* ProfileViewDelegate.swift */,
 				1A83F0302B80E6CB00E6EC89 /* ProfileViewBuilder.swift */,
 				1A83F0322B80E6E000E6EC89 /* ProfileViewModel.swift */,
 				1ACE49552B5B9E9300024336 /* ProfileView.swift */,
@@ -1037,6 +1043,7 @@
 				1A83F0382B80E8E200E6EC89 /* SplashViewBuilder.swift in Sources */,
 				1A44AAAC2B67EFCD006D8894 /* CreateProfile.Req.swift in Sources */,
 				1A8F13092B8B7DAB001E0237 /* LinkStringSet.swift in Sources */,
+				1AFB7D9E2B9D9481007E4D2F /* ProfileViewDelegate.swift in Sources */,
 				1AC781202B90E81500E298E3 /* RepositoryError.swift in Sources */,
 				1A8F12F12B87A33C001E0237 /* MBTIBoardUseCase.swift in Sources */,
 				1A7B069E2B5D702D0024356C /* APIEnvironment.swift in Sources */,
@@ -1053,6 +1060,7 @@
 				1A83F02C2B80E1BD00E6EC89 /* HomeViewModel.swift in Sources */,
 				3EA875682B86492B00713C64 /* DeleteProfile.Res.swift in Sources */,
 				1A7B06A22B5D8C710024356C /* MatchingInfo.swift in Sources */,
+				1AFB7D9C2B9D9387007E4D2F /* MultiProfileListDelegate.swift in Sources */,
 				1ACE497D2B5BA3B600024336 /* CreateProfile.Res.swift in Sources */,
 				1A83F02E2B80E26B00E6EC89 /* MatchResultViewBuilder.swift in Sources */,
 				1A8F12EA2B8784B8001E0237 /* ProfileEditorPresentation.swift in Sources */,

--- a/FunchApp/Application/Dependency.swift
+++ b/FunchApp/Application/Dependency.swift
@@ -18,6 +18,11 @@ final class DIContainer: ObservableObject {
         let subwayStationRepository: SubwayStationRepository
     }
     
+    struct Delegate {
+        
+//        var ProfileViewDelegate: ProfileViewDelegate = ProfileDelegate
+    }
+    
     private(set) var dependency: Dependency
     
     private(set) var openUrl: OpenURLProtocol

--- a/FunchApp/Application/FunchApp.swift
+++ b/FunchApp/Application/FunchApp.swift
@@ -34,16 +34,15 @@ struct FunchApp: App {
                 }
                 .overlay {
                     if isSplashing {
-                        withAnimation(.easeOut) {
-                            SplashViewBuilder().body
-                        }
-                        
+                        SplashViewBuilder().body
                     }
                 }
             }
             .onAppear {
                 DispatchQueue.main.asyncAfter(deadline: .now() + 1.35) {
-                    isSplashing.toggle()
+                    withAnimation(.easeInOut) {
+                        isSplashing.toggle()
+                    }
                 }
             }
             .environmentObject(container)

--- a/FunchApp/Presentation/EasterEggScene/EasterEggView.swift
+++ b/FunchApp/Presentation/EasterEggScene/EasterEggView.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct EasterEggView: View {
-    
-    @Environment(\.dismiss) var dismiss
-    
     @StateObject var viewModel: EasterEggViewModel
 
+    @Environment(\.dismiss) var dismiss
+    
     var body: some View {
         ZStack {
             Color.gray900

--- a/FunchApp/Presentation/HomeScene/HomePresentation.swift
+++ b/FunchApp/Presentation/HomeScene/HomePresentation.swift
@@ -5,7 +5,7 @@
 //  Created by Geon Woo lee on 2/22/24.
 //
 
-import Foundation
+import SwiftUI
 
 enum HomePresentation: Hashable, Identifiable {
     var id: Int { hashValue }
@@ -15,4 +15,45 @@ enum HomePresentation: Hashable, Identifiable {
     case mbtiCollection
     case easterEgg
     case multiProfile
+}
+
+struct HomePresentationView: View {
+    @EnvironmentObject var container: DIContainer
+    @State var presentation: HomePresentation
+    
+    var viewModel: HomeViewModel
+    
+    var body: some View {
+        switch presentation {
+        case .profile:
+            NavigationStack {
+                ProfileViewBuilder(
+                    container,
+                    delegate: viewModel
+                ).body
+            }
+        case let .matchResult(matchingInfo):
+            NavigationStack {
+                MatchResultViewBuilder(
+                    container,
+                    matchingInfo: matchingInfo
+                ).body
+            }
+        case .mbtiCollection:
+            NavigationStack {
+                MBTIBoardViewBuilder(container).body
+            }
+        case .easterEgg:
+            NavigationStack {
+                EasterEggViewBuilder(container).body
+            }
+        case .multiProfile:
+            NavigationStack {
+                MultiProfileListViewBuilder(
+                    container,
+                    delegate: viewModel
+                ).body
+            }
+        }
+    }
 }

--- a/FunchApp/Presentation/HomeScene/HomeView.swift
+++ b/FunchApp/Presentation/HomeScene/HomeView.swift
@@ -8,9 +8,6 @@
 import SwiftUI
 
 struct HomeView: View {
-    
-    @EnvironmentObject var container: DIContainer
-    
     @StateObject var viewModel: HomeViewModel
     
     var body: some View {
@@ -102,37 +99,7 @@ struct HomeView: View {
             hideKeyboard()
         }
         .fullScreenCover(item: $viewModel.presentation) { presentation in
-            switch presentation {
-            case .profile:
-                NavigationStack {
-                    ProfileViewBuilder(container).body
-                }
-                .onDisappear {
-                    viewModel.send(action: .load)
-                }
-            case let .matchResult(matchingInfo):
-                NavigationStack {
-                    MatchResultViewBuilder(
-                        container,
-                        matchingInfo: matchingInfo
-                    ).body
-                }
-            case .mbtiCollection:
-                NavigationStack {
-                    MBTIBoardViewBuilder(container).body
-                }
-            case .easterEgg:
-                NavigationStack {
-                    EasterEggViewBuilder(container).body
-                }
-            case .multiProfile:
-                NavigationStack {
-                    MultiProfileListViewBuilder(container).body
-                }
-                .onDisappear {
-                    viewModel.send(action: .load)
-                }
-            }
+            HomePresentationView(presentation: presentation, viewModel: self.viewModel)
         }
         .toolbar {
             ToolbarItemGroup(placement: .topBarTrailing) {

--- a/FunchApp/Presentation/HomeScene/HomeViewBuilder.swift
+++ b/FunchApp/Presentation/HomeScene/HomeViewBuilder.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-final class HomeViewBuilder {
+final class HomeViewBuilder{
     
     private var container: DIContainer
     

--- a/FunchApp/Presentation/HomeScene/HomeViewModel.swift
+++ b/FunchApp/Presentation/HomeScene/HomeViewModel.swift
@@ -59,6 +59,7 @@ final class HomeViewModel: ObservableObject {
     
     private var useCase: UseCase
     private var container: DIContainer
+    private var cancellables = Set<AnyCancellable>()
     
     struct UseCase {
         let fetchProfile: DefaultFetchProfileUseCase
@@ -71,8 +72,6 @@ final class HomeViewModel: ObservableObject {
         self.container = container
     }
 
-    var cancellables = Set<AnyCancellable>()
-    
     func send(action: Action) {
         switch action {
         case .load:
@@ -166,5 +165,17 @@ final class HomeViewModel: ObservableObject {
                 guard let self else { return }
                 self.profile = profile
             }.store(in: &cancellables)
+    }
+}
+
+extension HomeViewModel: ProfileViewDelegate {
+    func delete(profile: Profile) {
+        self.send(action: .load)
+    }
+}
+
+extension HomeViewModel: MultiProfileListDelegate {
+    func change(profile: Profile) {
+        self.send(action: .load)
     }
 }

--- a/FunchApp/Presentation/MBTIBoardScene/MBTIBoardView.swift
+++ b/FunchApp/Presentation/MBTIBoardScene/MBTIBoardView.swift
@@ -8,10 +8,8 @@
 import SwiftUI
 
 struct MBTIBoardView: View {
-    
-    @Environment(\.dismiss) var dismiss
-    
     @StateObject var viewModel: MBTIBoardViewModel
+    @Environment(\.dismiss) var dismiss
     
     var body: some View {
         ZStack {

--- a/FunchApp/Presentation/MatchResultScene/MatchResultView.swift
+++ b/FunchApp/Presentation/MatchResultScene/MatchResultView.swift
@@ -9,11 +9,10 @@ import SwiftUI
 import SwiftUIPager
 
 struct MatchResultView: View {
-    
-    @Environment(\.dismiss) var dismiss
-    
     @StateObject var viewModel: MatchResultViewModel
     @StateObject var page: Page = .first()
+    
+    @Environment(\.dismiss) var dismiss
     
     var viewSize: CGSize = UIScreen.main.bounds.size
     

--- a/FunchApp/Presentation/MultiProfileScene/MultiProfileListDelegate.swift
+++ b/FunchApp/Presentation/MultiProfileScene/MultiProfileListDelegate.swift
@@ -1,0 +1,13 @@
+//
+//  MultiProfileListDelegate.swift
+//  FunchApp
+//
+//  Created by Geon Woo lee on 3/10/24.
+//
+
+import Foundation
+
+protocol MultiProfileListDelegate: AnyObject {
+    /// 프로필 변경
+    func change(profile: Profile)
+}

--- a/FunchApp/Presentation/MultiProfileScene/MultiProfileListPresentation.swift
+++ b/FunchApp/Presentation/MultiProfileScene/MultiProfileListPresentation.swift
@@ -5,11 +5,24 @@
 //  Created by Geon Woo lee on 3/2/24.
 //
 
-import Foundation
+import SwiftUI
 
 enum MultiProfileListPresentation: Hashable, Identifiable {
     var id: Int { hashValue }
     
     case create
-    case home
+}
+
+struct MultiProfileListPresentationView: View {
+    @EnvironmentObject var container: DIContainer
+    @State var presentation: MultiProfileListPresentation
+    
+    var body: some View {
+        switch presentation {
+        case .create:
+            NavigationStack {
+                ProfileEditorViewBuilder(container).body
+            }
+        }
+    }
 }

--- a/FunchApp/Presentation/MultiProfileScene/MultiProfileListView.swift
+++ b/FunchApp/Presentation/MultiProfileScene/MultiProfileListView.swift
@@ -8,12 +8,9 @@
 import SwiftUI
 
 struct MultiProfileListView: View {
+    @StateObject var viewModel: MultiProfileListViewModel
     
     @Environment(\.dismiss) var dismiss
-    
-    @EnvironmentObject var container: DIContainer
-    
-    @StateObject var viewModel: MultiProfileListViewModel
     
     var body: some View {
         ZStack {
@@ -62,32 +59,17 @@ struct MultiProfileListView: View {
             viewModel.send(action: .load)
         }
         .fullScreenCover(item: $viewModel.presentation) { presentation in
-            switch presentation {
-            case .create:
-                NavigationStack {
-                    ProfileEditorViewBuilder(container).body
-                }
-                .onDisappear {
-                    viewModel.send(action: .load)
-                }
-            case .home:
-                EmptyView()
-            }
+            MultiProfileListPresentationView(presentation: presentation)
         }
-        .onReceive(viewModel.$presentation) {
-            switch $0 {
-            case .home:
-                container.paths.removeAll()
-            default:
-                break
-            }
+        .onReceive(viewModel.$dismiss) { isDismiss in
+            if isDismiss { dismiss() }
         }
         .toolbarBackground(Color.gray900, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 Button {
-                    dismiss()
+                    viewModel.send(action: .dismiss)
                 } label: {
                     Image(.iconX)
                 }

--- a/FunchApp/Presentation/MultiProfileScene/MultiProfileListViewBuilder.swift
+++ b/FunchApp/Presentation/MultiProfileScene/MultiProfileListViewBuilder.swift
@@ -7,16 +7,26 @@
 
 import SwiftUI
 
-final class MultiProfileListViewBuilder {
+struct MultiProfileListViewBuilder {
     
     private var container: DIContainer
+    private var viewModel: MultiProfileListViewModel
+    private var delegate: MultiProfileListDelegate
     
-    init(_ container: DIContainer) {
+    init(
+        _ container: DIContainer,
+        delegate: MultiProfileListDelegate
+    ) {
         self.container = container
+        self.delegate = delegate
+        
+        self.viewModel = .init(
+            container: container,
+            delegate: delegate
+        )
     }
     
     var body: some View {
-        let viewModel = MultiProfileListViewModel(container: container)
         let view = MultiProfileListView(viewModel: viewModel)
         
         return view

--- a/FunchApp/Presentation/MultiProfileScene/MultiProfileListViewModel.swift
+++ b/FunchApp/Presentation/MultiProfileScene/MultiProfileListViewModel.swift
@@ -13,6 +13,7 @@ final class MultiProfileListViewModel: ObservableObject {
         case load
         case selection(Profile)
         case presentation(MultiProfileListPresentation)
+        case dismiss
     }
     
     @Published var presentation: MultiProfileListPresentation?
@@ -20,11 +21,17 @@ final class MultiProfileListViewModel: ObservableObject {
     @Published var profiles: [Profile] = [.empty, .testableValue]
     /// 유저가 선택한 프로필
     @Published var selection: Profile?
+    @Published var dismiss: Bool = false
     
     private var container: DIContainer
-
-    init(container: DIContainer) {
+    weak var delegate: MultiProfileListDelegate?
+    
+    init(
+        container: DIContainer,
+        delegate: MultiProfileListDelegate
+    ) {
         self.container = container
+        self.delegate = delegate
     }
     
     func send(action: Action) {
@@ -42,6 +49,11 @@ final class MultiProfileListViewModel: ObservableObject {
         
         case let .presentation(presentation):
             self.presentation = presentation
+            
+        case .dismiss:
+            guard let profile = self.selection else { return }
+            delegate?.change(profile: profile)
+            dismiss = true
         }
     }
 }

--- a/FunchApp/Presentation/ProfileEditorScene/ProfileEditorView.swift
+++ b/FunchApp/Presentation/ProfileEditorScene/ProfileEditorView.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct ProfileEditorView: View {
+    @StateObject var viewModel: ProfileEditorViewModel
     
     @Environment(\.dismiss) var dismiss
     
-    @StateObject var viewModel: ProfileEditorViewModel
-        
     var body: some View {
         ZStack {
             Color.gray900

--- a/FunchApp/Presentation/ProfileEditorScene/ProfileEditorViewModel.swift
+++ b/FunchApp/Presentation/ProfileEditorScene/ProfileEditorViewModel.swift
@@ -162,7 +162,6 @@ final class ProfileEditorViewModel: ObservableObject {
     }
 }
 
-
 extension ProfileEditorViewModel {
     private func makeCreateUserQuery() -> CreateUserQuery {
         let major = majors.map { major in

--- a/FunchApp/Presentation/ProfileScene/ProfileView.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileView.swift
@@ -8,11 +8,10 @@
 import SwiftUI
 
 struct ProfileView: View {
-    
-    @Environment(\.dismiss) var dismiss
-    
     @StateObject var viewModel: ProfileViewModel
     @EnvironmentObject var diContainer: DIContainer
+    
+    @Environment(\.dismiss) var dismiss
     
     var body: some View {
         ZStack {
@@ -127,7 +126,6 @@ struct ProfileView: View {
         }
         .toolbarBackground(Color.gray900, for: .navigationBar)
     }
-    
     
     private func profileView(_ profile: Profile) -> some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/FunchApp/Presentation/ProfileScene/ProfileViewBuilder.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileViewBuilder.swift
@@ -6,22 +6,33 @@
 //
 
 import SwiftUI
+import Combine
 
 struct ProfileViewBuilder {
     
     private var container: DIContainer
+    private var viewModel: ProfileViewModel
+    private var delegate: ProfileViewDelegate
     
-    init(_ container: DIContainer) {
+    init(
+        _ container: DIContainer,
+        delegate: ProfileViewDelegate
+    ) {
         self.container = container
+        self.delegate = delegate
+        
+        let useCase = DefaultDeleteProfileUseCase(profileRepository: container.dependency.profileRepository)
+        
+        self.viewModel = .init(
+            container: container,
+            useCase: useCase,
+            delegate: delegate
+        )
     }
     
     var body: some View {
-        let useCase = DefaultDeleteProfileUseCase(profileRepository: container.dependency.profileRepository)
-        let viewModel = ProfileViewModel(
-            container: container,
-            useCase: useCase
-        )
         let view = ProfileView(viewModel: viewModel)
+        
         return view
     }
 }

--- a/FunchApp/Presentation/ProfileScene/ProfileViewDelegate.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileViewDelegate.swift
@@ -1,0 +1,11 @@
+//
+//  ProfileViewDelegate.swift
+//  FunchApp
+//
+//  Created by Geon Woo lee on 3/10/24.
+//
+
+protocol ProfileViewDelegate: AnyObject {
+    /// 프로필 삭제시 호출
+    func delete(profile: Profile)
+}

--- a/FunchApp/Presentation/ProfileScene/ProfileViewModel.swift
+++ b/FunchApp/Presentation/ProfileScene/ProfileViewModel.swift
@@ -39,15 +39,18 @@ final class ProfileViewModel: ObservableObject {
     
     private var useCase: DeleteProfileUseCase
     private var container: DIContainer
+    weak var delegate: ProfileViewDelegate?
     
     private var cancellables = Set<AnyCancellable>()
     
     init(
         container: DIContainer,
-        useCase: DeleteProfileUseCase
+        useCase: DeleteProfileUseCase,
+        delegate: ProfileViewDelegate
     ) {
         self.container = container
         self.useCase = useCase
+        self.delegate = delegate
     }
     
     func send(action: Action) {
@@ -64,7 +67,6 @@ final class ProfileViewModel: ObservableObject {
             
         case .deleteProfile:
             guard let userId = profile?.userId else { return }
-            
             useCase.execute(requestId: userId)
                 .sink { _ in
                     
@@ -79,8 +81,8 @@ final class ProfileViewModel: ObservableObject {
                         self.presentation = .onboarding
                     } else {
                         self.presentation = .home
+                        delegate?.delete(profile: profile)
                     }
-                    
                 }
                 .store(in: &cancellables)
             
@@ -95,6 +97,7 @@ final class ProfileViewModel: ObservableObject {
         case let .alert(type):
             showsAlert = true
             alertMessage = type
+            
         }
         
     }


### PR DESCRIPTION
## 이슈번호

## Presentation Layer 구조
 - Delegate, Builder, ViewModel, View, Presentation으로 구조 확립
    - Deleagte: 해당 뷰에서 발생하는 이벤트를 외부로 전달하기 위해서 사용
    - Builder: Builder를 활용하여 viewModel, view, useCase, presentation 등을 구성
    - Presentation: 해당 뷰에서 presentation 방식으로 띄우는 화면을 정의
    
## NavigationDestination
 - 화면 push 및 pop 등은 DIContainer 내에서 담당. 
 - Presentation이랑 별도로 분리하는 이유는 Navigation 방식으로 뎁스를 매우 깊게 가져가지 않아서 케이스가 엄청 다양하지 않음.
 - Presentation은 상대적으로 매우 다양함.

## 구조 및 자세한 설명은
 - https://rldd.tistory.com/598

## 참조
